### PR TITLE
fix deprecation warning when rendering blank page

### DIFF
--- a/app/controllers/debug_controller.rb
+++ b/app/controllers/debug_controller.rb
@@ -1,6 +1,6 @@
 class DebugController < ApplicationController
   def empty
-    render nothing: true
+    head :ok
   end
 
   def ping


### PR DESCRIPTION
Rails 5.1 will drop support for `render nothing: true`, so let's change it to be `head :ok` instead to return a blank page with status code 200.
