### PR TITLE
More deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+ruby "2.3.1"
+
 gem "rails", "5.0.0"
 gem "pg", "~> 0.18.4"
 gem "httparty", "~> 0.14.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,5 +134,8 @@ DEPENDENCIES
   rails (= 5.0.0)
   rails_12factor (~> 0.0.3)
 
+RUBY VERSION
+   ruby 2.3.1p112
+
 BUNDLED WITH
    1.12.5

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier


### PR DESCRIPTION
`config.serve_static_files` is going to be deprecated in 5.1, use `config.public_file_server.enabled` instead.
